### PR TITLE
updated compat stuff

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,12 +13,12 @@ Missings = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-DataFrames = "0.20,0.21"
+DataFrames = "0, 1"
 EzXML = "^1"
-HTTP = "^0.8"
-Interpolations = "^0.12, 0.13"
-Missings = "^0.4"
-Reexport = "^0.2"
+HTTP = "^0.8, 0.9, 1"
+Interpolations = "^0.12, 0.13, 0.14"
+Missings = "^0.4, 1.0"
+Reexport = "^0.2, 1.2"
 julia = "^1"
 
 [extras]


### PR DESCRIPTION
Hi @tbeason, nifty little package! 

Was just trying to use it for a blog post and ran into compat issues. I've updated these here, but tests are throwing errors:

```julia
julia> versioninfo()
Julia Version 1.9.3
Commit bed2cd540a1 (2023-08-24 14:43 UTC)
Build Info:
  Official https://julialang.org/ release
Platform Info:
  OS: macOS (arm64-apple-darwin22.4.0)
  CPU: 10 × Apple M2 Pro
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-14.0.6 (ORCJIT, apple-m1)
  Threads: 6 on 6 virtual cores
Environment:
  JULIA_EDITOR = code

(DailyTreasuryYieldCurve) pkg> test
     Testing DailyTreasuryYieldCurve
      Status `/private/var/folders/ct/w1pc0ggd44907l8fkl8m5pdslbh6sh/T/jl_mafwiG/Project.toml`
  [9f24bdcd] DailyTreasuryYieldCurve v0.2.2 `~/code/DailyTreasuryYieldCurve.jl`
  [ade2ca70] Dates `@stdlib/Dates`
  [8dfed614] Test `@stdlib/Test`
      Status `/private/var/folders/ct/w1pc0ggd44907l8fkl8m5pdslbh6sh/T/jl_mafwiG/Manifest.toml`
  [79e6a3ab] Adapt v3.6.2
  [13072b0f] AxisAlgorithms v1.0.1
  [d1d4a3ce] BitFlags v0.1.7
  [d360d2e6] ChainRulesCore v1.16.0
  [944b1d66] CodecZlib v0.7.2
  [34da2185] Compat v4.10.0
  [f0e56b4a] ConcurrentUtilities v2.2.1
  [a8cc5b0e] Crayons v4.1.1
  [9f24bdcd] DailyTreasuryYieldCurve v0.2.2 `~/code/DailyTreasuryYieldCurve.jl`
  [9a962f9c] DataAPI v1.15.0
  [a93c6f00] DataFrames v1.6.1
  [864edb3b] DataStructures v0.18.15
  [e2d170a0] DataValueInterfaces v1.0.0
  [460bff9d] ExceptionUnwrapping v0.1.9
  [8f5d6c58] EzXML v1.1.0
  [cd3eb016] HTTP v1.10.0
  [842dd82b] InlineStrings v1.4.0
  [a98d9a8b] Interpolations v0.14.7
  [41ab1584] InvertedIndices v1.3.0
  [82899510] IteratorInterfaceExtensions v1.0.0
  [692b3bcd] JLLWrappers v1.5.0
  [b964fa9f] LaTeXStrings v1.3.0
  [e6f89c97] LoggingExtras v1.0.3
  [739be429] MbedTLS v1.1.7
  [e1d29d7a] Missings v1.1.0
  [6fe1bfb0] OffsetArrays v1.12.10
  [4d8831e6] OpenSSL v1.4.1
  [bac558e1] OrderedCollections v1.6.2
  [69de0a69] Parsers v2.7.2
  [2dfb63ee] PooledArrays v1.4.3
  [aea7be01] PrecompileTools v1.2.0
  [21216c6a] Preferences v1.4.1
  [08abe8d2] PrettyTables v2.2.7
  [c84ed2f1] Ratios v0.4.5
  [189a3867] Reexport v1.2.2
  [ae029012] Requires v1.3.0
  [91c51154] SentinelArrays v1.4.0
  [777ac1f9] SimpleBufferStream v1.1.0
  [a2af1166] SortingAlgorithms v1.1.1
  [90137ffa] StaticArrays v1.6.5
  [1e83bf80] StaticArraysCore v1.4.2
  [892a3eda] StringManipulation v0.3.4
  [3783bdb8] TableTraits v1.0.1
  [bd369af6] Tables v1.11.0
  [3bb67fe8] TranscodingStreams v0.9.13
  [5c2747f8] URIs v1.5.0
  [efce3f68] WoodburyMatrices v0.5.5
  [94ce4f54] Libiconv_jll v1.17.0+0
  [458c3c95] OpenSSL_jll v3.0.11+0
  [02c8fc9c] XML2_jll v2.11.5+0
  [0dad84c5] ArgTools v1.1.1 `@stdlib/ArgTools`
  [56f22d72] Artifacts `@stdlib/Artifacts`
  [2a0f44e3] Base64 `@stdlib/Base64`
  [ade2ca70] Dates `@stdlib/Dates`
  [8ba89e20] Distributed `@stdlib/Distributed`
  [f43a241f] Downloads v1.6.0 `@stdlib/Downloads`
  [7b1f6079] FileWatching `@stdlib/FileWatching`
  [9fa8497b] Future `@stdlib/Future`
  [b77e0a4c] InteractiveUtils `@stdlib/InteractiveUtils`
  [b27032c2] LibCURL v0.6.3 `@stdlib/LibCURL`
  [76f85450] LibGit2 `@stdlib/LibGit2`
  [8f399da3] Libdl `@stdlib/Libdl`
  [37e2e46d] LinearAlgebra `@stdlib/LinearAlgebra`
  [56ddb016] Logging `@stdlib/Logging`
  [d6f4376e] Markdown `@stdlib/Markdown`
  [a63ad114] Mmap `@stdlib/Mmap`
  [ca575930] NetworkOptions v1.2.0 `@stdlib/NetworkOptions`
  [44cfe95a] Pkg v1.9.2 `@stdlib/Pkg`
  [de0858da] Printf `@stdlib/Printf`
  [3fa0cd96] REPL `@stdlib/REPL`
  [9a3f8284] Random `@stdlib/Random`
  [ea8e919c] SHA v0.7.0 `@stdlib/SHA`
  [9e88b42a] Serialization `@stdlib/Serialization`
  [1a1011a3] SharedArrays `@stdlib/SharedArrays`
  [6462fe0b] Sockets `@stdlib/Sockets`
  [2f01184e] SparseArrays `@stdlib/SparseArrays`
  [10745b16] Statistics v1.9.0 `@stdlib/Statistics`
  [fa267f1f] TOML v1.0.3 `@stdlib/TOML`
  [a4e569a6] Tar v1.10.0 `@stdlib/Tar`
  [8dfed614] Test `@stdlib/Test`
  [cf7118a7] UUIDs `@stdlib/UUIDs`
  [4ec0a83e] Unicode `@stdlib/Unicode`
  [e66e0078] CompilerSupportLibraries_jll v1.0.5+0 `@stdlib/CompilerSupportLibraries_jll`
  [deac9b47] LibCURL_jll v7.84.0+0 `@stdlib/LibCURL_jll`
  [29816b5a] LibSSH2_jll v1.10.2+0 `@stdlib/LibSSH2_jll`
  [c8ffd9c3] MbedTLS_jll v2.28.2+0 `@stdlib/MbedTLS_jll`
  [14a3606d] MozillaCACerts_jll v2022.10.11 `@stdlib/MozillaCACerts_jll`
  [4536629a] OpenBLAS_jll v0.3.21+4 `@stdlib/OpenBLAS_jll`
  [bea87d4a] SuiteSparse_jll v5.10.1+6 `@stdlib/SuiteSparse_jll`
  [83775a58] Zlib_jll v1.2.13+0 `@stdlib/Zlib_jll`
  [8e850b90] libblastrampoline_jll v5.8.0+0 `@stdlib/libblastrampoline_jll`
  [8e850ede] nghttp2_jll v1.48.0+0 `@stdlib/nghttp2_jll`
  [3f19e933] p7zip_jll v17.4.0+0 `@stdlib/p7zip_jll`
     Testing Running tests...
┌ Warning: caught 100 errors; showing the first one
└ @ EzXML ~/.julia/packages/EzXML/ZNwhK/src/error.jl:79
ERROR: LoadError: XMLError: Double hyphen within comment: <!-- 
         __  __  ____    ______                  from XML parser (code: 80, line: 6)
Stacktrace:
 [1] throw_xml_error()
   @ EzXML ~/.julia/packages/EzXML/ZNwhK/src/error.jl:87
 [2] macro expansion
   @ ~/.julia/packages/EzXML/ZNwhK/src/error.jl:52 [inlined]
 [3] parsexml(xmlstring::String)
   @ EzXML ~/.julia/packages/EzXML/ZNwhK/src/document.jl:80
 [4] getyieldcurves(; realrates::Bool, begdt::Date, enddt::Date)
   @ DailyTreasuryYieldCurve ~/code/DailyTreasuryYieldCurve.jl/src/DailyTreasuryYieldCurve.jl:54
 [5] getyieldcurves()
   @ DailyTreasuryYieldCurve ~/code/DailyTreasuryYieldCurve.jl/src/DailyTreasuryYieldCurve.jl:45
 [6] top-level scope
   @ ~/code/DailyTreasuryYieldCurve.jl/test/runtests.jl:4
 [7] include(fname::String)
   @ Base.MainInclude ./client.jl:478
 [8] top-level scope
   @ none:6
in expression starting at /Users/paltmeyer/code/DailyTreasuryYieldCurve.jl/test/runtests.jl:4
ERROR: 
╭─────────────────────────────────────────────────────────── ErrorException ───────────────────────────────────────────────────────────╮
│                                                                                                                                      │
│  Package DailyTreasuryYieldCurve errored during testing                                                                              │
│                                                                                                                                      │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯


(DailyTreasuryYieldCurve) pkg> 
```

Thought I'd create a PR anyway in case you want to have a look in the future.

Cheers!